### PR TITLE
#78 App not passively downloading

### DIFF
--- a/src/features/Bluetooth/Download/DownloadSlice.ts
+++ b/src/features/Bluetooth/Download/DownloadSlice.ts
@@ -162,7 +162,6 @@ function* startPassiveDownloading(): SagaIterator {
 }
 
 function* watchPassiveDownloading(): SagaIterator {
-  yield take(DownloadAction.passiveDownloadingStart);
   yield race({
     start: call(startPassiveDownloading),
     stop: take(DownloadAction.passiveDownloadingStop),


### PR DESCRIPTION
Fixes #78 



Extra `take` here. The saga is already invoked when the same action is dispatched, so this is blocking, waiting for the action to be dispatched a second time, which is not what we want