### PR TITLE
#89 sensor display tweaks

### DIFF
--- a/__tests__/common/constants/__snapshots__/Chart.test.js.snap
+++ b/__tests__/common/constants/__snapshots__/Chart.test.js.snap
@@ -5,7 +5,7 @@ Object {
   "2": "X_DOMAIN_PADDING",
   "20": "Y_DOMAIN_PADDING",
   "5": "NUMBER_OF_TICKS_Y",
-  "INTERPOLATION": "natural",
+  "INTERPOLATION": "catmullRom",
   "LINE_GRADIENT_ID": "url(#grad)",
   "NUMBER_OF_TICKS_Y": 5,
   "X_DOMAIN_PADDING": 2,

--- a/src/common/constants/Chart.ts
+++ b/src/common/constants/Chart.ts
@@ -2,7 +2,7 @@ export enum CHART {
   NUMBER_OF_TICKS_Y = 5,
   X_KEY = 'timestamp',
   Y_KEY = 'temperature',
-  INTERPOLATION = 'natural',
+  INTERPOLATION = 'catmullRom',
   LINE_GRADIENT_ID = 'url(#grad)',
   X_DOMAIN_PADDING = 2,
   Y_DOMAIN_PADDING = 20,

--- a/src/ui/components/SensorTemperatureStatus.tsx
+++ b/src/ui/components/SensorTemperatureStatus.tsx
@@ -81,11 +81,11 @@ export const SensorTemperatureStatusComponent: FC<SensorTemperatureStatusProps> 
     <TouchableOpacity onLongPress={startAcknowledging}>
       <LargeRectangle color={hasColdBreach ? COLOUR.PRIMARY : COLOUR.DANGER}>
         <Row flex={1}>
-          <Centered style={{ left: 10 }}>
+          <Row justifyContent="flex-end" flex={1} style={{ left: 10 }}>
             <LargeText color={COLOUR.WHITE}>{temperature}</LargeText>
-          </Centered>
+          </Row>
 
-          <Centered>
+          <Row flex={1}>
             <Animated.View style={{ ...styles.icon, opacity: fadeAnim1 }}>
               <Icon.HotBreach />
             </Animated.View>
@@ -97,7 +97,7 @@ export const SensorTemperatureStatusComponent: FC<SensorTemperatureStatusProps> 
             <Animated.View style={{ ...styles.icon, opacity: fadeAnim3 }}>
               <Icon.LowBattery />
             </Animated.View>
-          </Centered>
+          </Row>
         </Row>
       </LargeRectangle>
     </TouchableOpacity>

--- a/src/ui/layouts/SensorStatusLayout.tsx
+++ b/src/ui/layouts/SensorStatusLayout.tsx
@@ -1,5 +1,5 @@
 import React, { FC, ReactNode } from 'react';
-import { ActivityIndicator, View } from 'react-native';
+import { ActivityIndicator } from 'react-native';
 import { Row } from '~layouts/Row';
 import { COLOUR } from '../../common/constants';
 import { Column } from './Column';
@@ -28,8 +28,8 @@ export const SensorStatusLayout: FC<SensorStatusLayoutProps> = ({
         <Row style={{ marginLeft: 5 }} />
         {SensorStatusBar}
       </Row>
-      <View>{TemperatureStatus}</View>
-      <Column flex={1}>
+      <Row justifyContent="flex-end" style={{paddingRight: 20}}>{TemperatureStatus}</Row>
+      <Column flex={1} alignItems="flex-end" style={{paddingRight: 25}}>
         {LastDownload}
         {CumulativeBreach}
       </Column>


### PR DESCRIPTION
Fixes #89 

Updated the layout, so that the boxes are vertically aligned. Aligned the breach icon and right-aligned the updated text as that looked better.

After aligning the temps, went with 1dp display as that looks more consistent. 
Some examples below

Have updated the chart interpolation type as well, along the lines of https://github.com/openmsupply/mobile/pull/3567 as I saw some of the same strangeness in the screenshots provided.

As noted, the row separator appears to have been removed, and the cold breach text ( was going to replace `-` with `&` but no need now )
Could recreate the other issues.

![alignment2](https://user-images.githubusercontent.com/9192912/119766230-c1fa9300-bf08-11eb-8fa7-bed5a447b5e0.png)

![alignment3](https://user-images.githubusercontent.com/9192912/119766255-d2ab0900-bf08-11eb-9534-b45e89327db3.png)

![alignment4](https://user-images.githubusercontent.com/9192912/119766263-d63e9000-bf08-11eb-9efc-4f5506c34170.png)


