### PR TITLE
x-axis vertical alignment

### DIFF
--- a/src/common/constants/Chart.ts
+++ b/src/common/constants/Chart.ts
@@ -6,4 +6,6 @@ export enum CHART {
   LINE_GRADIENT_ID = 'url(#grad)',
   X_DOMAIN_PADDING = 2,
   Y_DOMAIN_PADDING = 20,
+  HEIGHT_FACTOR = 0.15,
+  WIDTH_FACTOR = 0.6,
 }

--- a/src/ui/components/SensorChartRow.tsx
+++ b/src/ui/components/SensorChartRow.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useOnMount } from '../hooks';
 import {
   ChartAction,
-  CumulativeBreachAction,
+  // CumulativeBreachAction,
   SensorStatusAction,
   SensorStatusSelector,
   ChartSelector,
@@ -16,6 +16,7 @@ import { Chart } from '../presentation';
 import { SensorStatus } from './SensorStatus';
 import { RootState } from '../../common/store/store';
 import { useWindowDimensions } from 'react-native';
+import { CHART } from '~constants';
 
 interface SensorChartRowProps {
   id: string;
@@ -49,8 +50,8 @@ export const SensorChartRow: FC<SensorChartRowProps> = React.memo(({ id, onPress
         <Chart
           isLoading={isLoadingChartData}
           data={data}
-          width={width * 0.6}
-          height={height * 0.15}
+          width={width * CHART.WIDTH_FACTOR}
+          height={height * CHART.HEIGHT_FACTOR}
         />
       }
       SensorStatus={

--- a/src/ui/layouts/SensorRowLayout.tsx
+++ b/src/ui/layouts/SensorRowLayout.tsx
@@ -1,18 +1,10 @@
 import React, { FC, ReactNode } from 'react';
 import { TouchableOpacity } from 'react-native';
 
-import { STYLE } from '../../common/constants';
-
 import { Column } from './Column';
 import { Row } from './Row';
 import { HalfCircleButton } from '../components/buttons';
 import { Icon } from '../presentation/icons';
-
-const styles = {
-  row: {
-    height: 175,
-  },
-};
 
 interface SensorRowLayoutProps {
   Chart: ReactNode;
@@ -27,9 +19,10 @@ export const SensorRowLayout: FC<SensorRowLayoutProps> = ({
   onPress,
   direction,
 }) => {
+
   return (
     <TouchableOpacity onPress={onPress}>
-      <Row style={styles.row}>
+      <Row >
         <Column flex={3} justifyContent="center">
           {Chart}
         </Column>

--- a/src/ui/presentation/Chart.tsx
+++ b/src/ui/presentation/Chart.tsx
@@ -68,6 +68,12 @@ export const Chart: FC<ChartProps> = ({ data = [], isLoading, width, height }) =
     </Row>
   );
 
+  // currently a small bug with the x-axis placement when values are both +ve and -ve on the chart
+  const dataValues = data.map(d => d.temperature);
+  const minValue = Math.min(...dataValues);
+  const maxValue = Math.max(...dataValues);
+  const offsetY = minValue < 0 && maxValue > 0 ? maxValue - minValue : 0;
+  
   return (
     <View
       style={{
@@ -86,6 +92,7 @@ export const Chart: FC<ChartProps> = ({ data = [], isLoading, width, height }) =
             {/* X AXIS */}
             <VictoryAxis
               orientation="bottom"
+              offsetY={offsetY}
               style={style.xAxis}
               tickFormat={tickFormatter}
               tickCount={5}


### PR DESCRIPTION
Fixes #89 
Resolves the problem with the x-axis appearing mid-way up the chart when it has both positive and negative values to display.

The result is this: which shows all-positive, all-negative and a mix:

![xaxis](https://user-images.githubusercontent.com/9192912/119934132-6fd57280-bfd9-11eb-823d-fe75f0fa3f6b.png)

Also removed the fixed row height on the chart, as that was causing the charts to bump into each other.