### PR TITLE
Handle back in bottomTabBar

### DIFF
--- a/src/ui/containers/MainTabNavigator.tsx
+++ b/src/ui/containers/MainTabNavigator.tsx
@@ -56,7 +56,7 @@ const tabBarOptions: BottomTabBarOptions = {
 };
 
 export const MainTabNavigator: FC = ({ children }) => (
-  <Tab.Navigator screenOptions={screenOptions} tabBarOptions={tabBarOptions}>
+  <Tab.Navigator screenOptions={screenOptions} tabBarOptions={tabBarOptions} backBehavior="history">
     {children}
   </Tab.Navigator>
 );

--- a/src/ui/screens/sensors/Sensors.tsx
+++ b/src/ui/screens/sensors/Sensors.tsx
@@ -6,11 +6,9 @@ import { SensorListScreen } from './SensorListScreen';
 import { SensorDetailScreen } from './SensorDetailScreen';
 import { SENSOR_STACK } from '../../../common/constants/Navigation';
 
-export const Sensors: FC = () => {
-  return (
-    <SensorStackNavigator>
-      <SensorStackScreen name={SENSOR_STACK.TABS} component={SensorListScreen} />
-      <SensorStackScreen name={SENSOR_STACK.SENSOR_DETAIL} component={SensorDetailScreen} />
-    </SensorStackNavigator>
-  );
-};
+export const Sensors: FC = () => (
+  <SensorStackNavigator>
+    <SensorStackScreen name={SENSOR_STACK.TABS} component={SensorListScreen} />
+    <SensorStackScreen name={SENSOR_STACK.SENSOR_DETAIL} component={SensorDetailScreen} />
+  </SensorStackNavigator>
+);


### PR DESCRIPTION
Fixes #150 

With the behaviour for back button specified in the bottom tab navigator, was unable to repro.
Could repro prior to the change, so this may resolve the problem.