### PR TITLE
tidy flex usage for status

### DIFF
--- a/src/ui/components/SensorTemperatureStatus.tsx
+++ b/src/ui/components/SensorTemperatureStatus.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Animated, TouchableOpacity, ViewStyle } from 'react-native';
+import { Animated, TouchableOpacity } from 'react-native';
 import { MILLISECONDS, COLOUR } from '../../common/constants';
 import { SensorStatusSelector, AcknowledgeBreachAction } from '../../features';
 import { Row, Centered, LargeRectangle } from '../layouts';
@@ -81,19 +81,19 @@ export const SensorTemperatureStatusComponent: FC<SensorTemperatureStatusProps> 
             <LargeText color={COLOUR.WHITE}>{temperature}</LargeText>
           </Row>
           <Row style={{ display: 'flex', flex: 2 }} justifyContent="center" alignItems="center">
-            {hasHotBreach && (
+            {!!hasHotBreach && (
               <Animated.View style={{ opacity: fadeAnim1 }}>
                 <Icon.HotBreach />
               </Animated.View>
             )}
 
-            {hasColdBreach && (
+            {!!hasColdBreach && (
               <Animated.View style={{ opacity: fadeAnim2 }}>
                 <Icon.ColdBreach />
               </Animated.View>
             )}
 
-            {isLowBattery && (
+            {!!isLowBattery && (
               <Animated.View style={{ opacity: fadeAnim3 }}>
                 <Icon.LowBattery />
               </Animated.View>

--- a/src/ui/components/SensorTemperatureStatus.tsx
+++ b/src/ui/components/SensorTemperatureStatus.tsx
@@ -8,10 +8,6 @@ import { Header, LargeText } from '../presentation/typography';
 import { Icon } from '../presentation/icons';
 import { RootState } from '../../common/store/store';
 
-const styles: { icon: ViewStyle } = {
-  icon: { position: 'absolute', left: 40 },
-};
-
 const getAnimations = (animationValues: Animated.Value[]) => {
   return Animated.loop(
     Animated.sequence(
@@ -80,23 +76,28 @@ export const SensorTemperatureStatusComponent: FC<SensorTemperatureStatusProps> 
   ) : (
     <TouchableOpacity onLongPress={startAcknowledging}>
       <LargeRectangle color={hasColdBreach ? COLOUR.PRIMARY : COLOUR.DANGER}>
-        <Row flex={1}>
-          <Row justifyContent="flex-end" flex={1} style={{ left: 10 }}>
+        <Row style={{ display: 'flex', alignContent: 'flex-end' }}>
+          <Row justifyContent="flex-end" flex={3}>
             <LargeText color={COLOUR.WHITE}>{temperature}</LargeText>
           </Row>
+          <Row style={{ display: 'flex', flex: 2 }} justifyContent="center" alignItems="center">
+            {hasHotBreach && (
+              <Animated.View style={{ opacity: fadeAnim1 }}>
+                <Icon.HotBreach />
+              </Animated.View>
+            )}
 
-          <Row flex={1}>
-            <Animated.View style={{ ...styles.icon, opacity: fadeAnim1 }}>
-              <Icon.HotBreach />
-            </Animated.View>
+            {hasColdBreach && (
+              <Animated.View style={{ opacity: fadeAnim2 }}>
+                <Icon.ColdBreach />
+              </Animated.View>
+            )}
 
-            <Animated.View style={{ ...styles.icon, opacity: fadeAnim2 }}>
-              <Icon.ColdBreach />
-            </Animated.View>
-
-            <Animated.View style={{ ...styles.icon, opacity: fadeAnim3 }}>
-              <Icon.LowBattery />
-            </Animated.View>
+            {isLowBattery && (
+              <Animated.View style={{ opacity: fadeAnim3 }}>
+                <Icon.LowBattery />
+              </Animated.View>
+            )}
           </Row>
         </Row>
       </LargeRectangle>

--- a/src/ui/components/SensorTemperatureStatus.tsx
+++ b/src/ui/components/SensorTemperatureStatus.tsx
@@ -1,12 +1,16 @@
 import React, { FC, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Animated, TouchableOpacity } from 'react-native';
-import { MILLISECONDS, COLOUR } from '../../common/constants';
+import { Animated, TouchableOpacity, ViewStyle } from 'react-native';
+import { MILLISECONDS, COLOUR, STYLE } from '../../common/constants';
 import { SensorStatusSelector, AcknowledgeBreachAction } from '../../features';
 import { Row, Centered, LargeRectangle } from '../layouts';
 import { Header, LargeText } from '../presentation/typography';
-import { Icon } from '../presentation/icons';
+import { Icon, ICON_SIZE } from '../presentation/icons';
 import { RootState } from '../../common/store/store';
+
+const styles: { icon: ViewStyle } = {
+  icon: { position: 'absolute', left: 20, top: 0 },
+};
 
 const getAnimations = (animationValues: Animated.Value[]) => {
   return Animated.loop(
@@ -76,25 +80,25 @@ export const SensorTemperatureStatusComponent: FC<SensorTemperatureStatusProps> 
   ) : (
     <TouchableOpacity onLongPress={startAcknowledging}>
       <LargeRectangle color={hasColdBreach ? COLOUR.PRIMARY : COLOUR.DANGER}>
-        <Row style={{ display: 'flex', alignContent: 'flex-end' }}>
+        <Row>
           <Row justifyContent="flex-end" flex={3}>
             <LargeText color={COLOUR.WHITE}>{temperature}</LargeText>
           </Row>
-          <Row style={{ display: 'flex', flex: 2 }} justifyContent="center" alignItems="center">
+          <Row style={{ flex: 2 }}>
             {!!hasHotBreach && (
-              <Animated.View style={{ opacity: fadeAnim1 }}>
+              <Animated.View style={{ ...styles.icon, opacity: fadeAnim1 }}>
                 <Icon.HotBreach />
               </Animated.View>
             )}
 
             {!!hasColdBreach && (
-              <Animated.View style={{ opacity: fadeAnim2 }}>
+              <Animated.View style={{ ...styles.icon, left: 10, opacity: fadeAnim2 }}>
                 <Icon.ColdBreach />
               </Animated.View>
             )}
 
             {!!isLowBattery && (
-              <Animated.View style={{ opacity: fadeAnim3 }}>
+              <Animated.View style={{ ...styles.icon, top: (STYLE.HEIGHT.LARGE_RECTANGLE - ICON_SIZE.MS) / 2, opacity: fadeAnim3 }}>
                 <Icon.LowBattery />
               </Animated.View>
             )}

--- a/src/ui/presentation/icons/LowBattery.tsx
+++ b/src/ui/presentation/icons/LowBattery.tsx
@@ -4,5 +4,5 @@ import { COLOUR } from '../../../common/constants';
 import { Icon, ICON_NAME, ICON_SIZE } from './Icon';
 
 export const LowBattery: FC = () => {
-  return <Icon size={ICON_SIZE.L} name={ICON_NAME.LOW_BATTERY} color={COLOUR.WHITE} />;
+  return <Icon size={ICON_SIZE.MS} name={ICON_NAME.LOW_BATTERY} color={COLOUR.WHITE} />;
 };


### PR DESCRIPTION
Fixes #155 

Updated the flex usage - this was behaving very strangely due to the rendering of all three icons, whether used or not. They were taking up space when not shown, causing layout issues.

Also made the battery icon smaller, this was the only usage, so have set the default size to be what I want.

Results:

![cold](https://user-images.githubusercontent.com/9192912/120141358-73166b80-c230-11eb-824b-411fa744ae9d.png)
![battery](https://user-images.githubusercontent.com/9192912/120141362-7578c580-c230-11eb-8243-8ba3be8b89f9.png)
![hot](https://user-images.githubusercontent.com/9192912/120141373-7873b600-c230-11eb-9231-a76487bd78d7.png)
