### PR TITLE
remove dev sync records section

### DIFF
--- a/src/ui/layouts/SensorDetailScreenLayout.tsx
+++ b/src/ui/layouts/SensorDetailScreenLayout.tsx
@@ -1,7 +1,6 @@
 import React, { FC, ReactNode } from 'react';
 import { View } from 'react-native';
 import { LoadAfterInteractions } from '../components';
-import { Centered } from './Centered';
 import { Gradient } from './Gradient';
 import { Row } from './Row';
 

--- a/src/ui/screens/settings/DevSettingsScreen.tsx
+++ b/src/ui/screens/settings/DevSettingsScreen.tsx
@@ -35,13 +35,6 @@ export const DevSettingsScreen: FC = () => {
           );
         })}
       </SettingsGroup>
-      <SettingsGroup title="Sync records">
-        <SettingsButtonRow
-          label="Sync all records"
-          subtext="Syncs all records currently stored in sync queue"
-          onPress={() => dispatch(SyncAction.enablePassiveSync())}
-        />
-      </SettingsGroup>
     </SettingsList>
   );
 };


### PR DESCRIPTION
Fixes #55 
Removes the developer sync section.
The section in sync settings has been renamed, but the function is the same.