### PR TITLE
#159 sensor status types

### DIFF
--- a/src/common/types/common.d.ts
+++ b/src/common/types/common.d.ts
@@ -5,3 +5,5 @@ export declare type PreparedAction<T> = {
 export declare type MacAddress = string;
 
 export declare type UnixTime = number;
+
+export type ById<SomeTypeSortedById> = Record<string, SomeTypeSortedById>;

--- a/src/features/Chart/ChartSlice.ts
+++ b/src/features/Chart/ChartSlice.ts
@@ -116,21 +116,7 @@ const isLoading = ({ chart: { listLoadingById } }: RootState, { id }: { id: stri
   return listLoadingById[id] ?? true;
 };
 
-const detailTimestamps = (
-  { sensorStatus }: RootState,
-  { id }: { id: string }
-): { from: number; to: number } => {
-  // TODO: Fix types
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { byId } = sensorStatus as Record<string, any>;
-  const { [id]: status } = byId;
-  const { minChartTimestamp, mostRecentLogTimestamp } = status ?? {};
-
-  return { from: minChartTimestamp, to: mostRecentLogTimestamp };
-};
-
 const ChartSelector = {
-  detailTimestamps,
   listData,
   detailData,
   isLoading,

--- a/src/features/Entities/Sensor/SensorSlice.ts
+++ b/src/features/Entities/Sensor/SensorSlice.ts
@@ -7,6 +7,7 @@ import { RootState } from '../../../common/store/store';
 import { REDUCER } from '../../../common/constants';
 import { ProgramAction } from '~features/Bluetooth/Program/ProgramSlice';
 import { getDependency } from '~features/utils/saga';
+import { ById } from '~common/types/common';
 
 export interface SensorState {
   id: string;
@@ -18,7 +19,6 @@ export interface SensorState {
   programmedDate: number;
 }
 
-export type ById<InterfaceSortedById> = Record<string, InterfaceSortedById>;
 export interface SensorSliceState {
   byId: ById<SensorState>;
   ids: string[];

--- a/src/features/SensorStatus/SensorStatusSlice.ts
+++ b/src/features/SensorStatus/SensorStatusSlice.ts
@@ -8,16 +8,10 @@ import { SensorAction } from '../Entities';
 import { FormatService } from '../../common/services';
 
 export interface SensorStatus {
-  name: string;
-  macAddress: string;
-  logInterval: number;
-  batteryLevel: number;
-  logDelay: number;
   mostRecentLogTimestamp: number;
   firstTimestamp: number;
   numberOfLogs: number;
   currentTemperature: number;
-  minChartTimestamp: number;
   isInHotBreach: boolean;
   isInColdBreach: boolean;
   hasHotBreach: boolean;


### PR DESCRIPTION
Fixes #159 

Maaaybe this is ugly and silly. I'm not sure. I think it's good to try and have the keys of the query match a typed result, I guess!

This is changing and tidying the query as well as the result to what is actually being used currently.

The other change to the query is to allow passing in a different filter for sensors. I plan to do another PR which will allow me to pass in a filter for just the active sensors, and then we can hydrate the app and get all the status' at once to hopefully reduce load time a little