### PR TITLE
Add sending of clear traffic

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
     android:roundIcon="@mipmap/ic_launcher"
     android:allowBackup="false"
     android:theme="@style/AppTheme"
+    android:usesCleartextTraffic="true"
   >
     <activity
       android:name=".MainActivity"


### PR DESCRIPTION
Fixes #173 
In more recent android os versions, you need to explicitly allow for http requests.

You can (preferred way) specify the exact domain for the http request, but since we won't know the domains, have just enabled for everything.