### PR TITLE
change battery range lower bound to 70

### DIFF
--- a/__tests__/common/services/UtilService/UtilService.test.js
+++ b/__tests__/common/services/UtilService/UtilService.test.js
@@ -25,11 +25,12 @@ describe('UtilService:normaliseNumber', () => {
   it('normalises a battery level correctly', () => {
     const utils = new UtilService();
 
-    expect(utils.normaliseNumber(75, [75, 100])).toBe(0);
-    expect(utils.normaliseNumber(80, [75, 100])).toBe(20);
-    expect(utils.normaliseNumber(85, [75, 100])).toBe(40);
-    expect(utils.normaliseNumber(90, [75, 100])).toBe(60);
-    expect(utils.normaliseNumber(95, [75, 100])).toBe(80);
-    expect(utils.normaliseNumber(100, [75, 100])).toBe(100);
+    expect(utils.normaliseNumber(70, [70, 100])).toBe(0);
+    expect(utils.normaliseNumber(75, [70, 100])).toBe(16);
+    expect(utils.normaliseNumber(80, [70, 100])).toBe(33);
+    expect(utils.normaliseNumber(85, [70, 100])).toBe(50);
+    expect(utils.normaliseNumber(90, [70, 100])).toBe(66);
+    expect(utils.normaliseNumber(95, [70, 100])).toBe(83);
+    expect(utils.normaliseNumber(100, [70, 100])).toBe(100);
   });
 });

--- a/src/common/services/Bluetooth/BleService.ts
+++ b/src/common/services/Bluetooth/BleService.ts
@@ -202,7 +202,7 @@ export class BleService {
 
         return Number.isNaN(batteryLevel)
           ? null
-          : this.utils.normaliseNumber(batteryLevel, [75, 100]);
+          : this.utils.normaliseNumber(batteryLevel, [70, 100]);
       };
 
       const parsedIsDisabled = (info: string): boolean => !!info.match(/Btn on\/off: 1/);

--- a/src/common/services/UtilService/UtilService.ts
+++ b/src/common/services/UtilService/UtilService.ts
@@ -38,7 +38,7 @@ export class UtilService {
 
     const newVal = ((currentVal - oldMin) * (newMax - newMin)) / (oldMax - oldMin) + newMin;
 
-    return newVal;
+    return Math.floor(newVal);
   };
 
   bufferFromBase64 = (base64: string): Buffer => Buffer.from(base64, 'base64');


### PR DESCRIPTION
Fixes #174 

I changed `75` to `70` 🥇 
( also adding a floor to the result, since the test changes resulted in real numbers with lots of decimal places )