### PR TITLE
Add different battery level listening implementation

### DIFF
--- a/src/ui/hooks/usePowerState.ts
+++ b/src/ui/hooks/usePowerState.ts
@@ -1,4 +1,4 @@
-import { MILLISECONDS } from './../../common/constants/Milliseconds';
+import { MILLISECONDS } from '~constants/Milliseconds';
 import { useEffect, useReducer, useRef } from 'react';
 import * as ExpoBattery from 'expo-battery';
 


### PR DESCRIPTION
#194 

So this is a bit hacky. I didn't want to add yet another package or touch java to add a listener to the actual android event, so instead.. just polling. Too hacky?