### PR TITLE
#201 Don't increment offset after first fetch (getMore will do the increment)

### DIFF
--- a/src/features/SensorDetail/LogTable/LogTableSlice.ts
+++ b/src/features/SensorDetail/LogTable/LogTableSlice.ts
@@ -110,10 +110,8 @@ const reducers = {
       draftState: LogTableSliceState,
       { payload: { data } }: PayloadAction<FetchSuccessPayload>
     ) => {
-      const { limit, offset } = draftState;
       draftState.data = data;
       draftState.isLoading = false;
-      draftState.offset = offset + limit;
     },
   },
   fetchFail: {


### PR DESCRIPTION
Fixes #201 

I think the offset is just being incremented twice after the initial fetch (once on fetchSuccess, and again on fetchMore) so far with local testing it seems like this should address the issue reported.