### PR TITLE
232 retrieve temp logs

### DIFF
--- a/.yalc/msupply-ble-service/lib/commonjs/Bluetooth/BleService.js
+++ b/.yalc/msupply-ble-service/lib/commonjs/Bluetooth/BleService.js
@@ -207,7 +207,9 @@ class BleService {
 
       if ((device === null || device === void 0 ? void 0 : device.deviceType) === _constants.BT510) {
         await this.downloadLogs(macAddress);
-      } else {
+      } 
+      else {
+        await this.downloadLogs(macAddress);
         await this.writeWithSingleResponse(device, _constants.BLUE_MAESTRO.COMMAND_CLEAR, data => !!this.utils.stringFromBase64(data));
       }
     });
@@ -314,18 +316,16 @@ class BleService {
 
     _defineProperty(this, "updateLogInterval", async (macAddress, logInterval, clearLogs = true) => {
       const device = await this.connectAndDiscoverServices(macAddress);
+      //need to download the logs before deleting logs
+      if (clearLogs) {
+        await this.downloadLogs(macAddress);
+      }
+      // BlueMaestro automatically clears logs when log interval is set,
       const command = device.deviceType.COMMAND_UPDATE_LOG_INTERVAL.replace('LOG_INTERVAL', logInterval.toString());
       const result = await this.writeWithSingleResponse(device, command, data => {
         const info = this.utils.stringFromBase64(data);
         return device.deviceType === _constants.BT510 && JSON.parse(info).result === 'ok' || !!info.match(/interval/i);
-      }); // Clear logs if we haven't just downloaded
-      // BlueMaestro automatically clears logs when log interval is set,
-      // But we have to download all the logs to clear them on BT510
-
-      if (clearLogs && device.deviceType === _constants.BT510) {
-        await this.downloadLogs(macAddress);
-      }
-
+      }); 
       if (result) return true;
       throw new Error(` command returned not OK result`);
     });

--- a/.yalc/msupply-ble-service/lib/module/Bluetooth/BleService.js
+++ b/.yalc/msupply-ble-service/lib/module/Bluetooth/BleService.js
@@ -193,7 +193,9 @@ export class BleService {
 
       if ((device === null || device === void 0 ? void 0 : device.deviceType) === BT510) {
         await this.downloadLogs(macAddress);
-      } else {
+      } 
+      else {
+        await this.downloadLogs(macAddress);
         await this.writeWithSingleResponse(device, BLUE_MAESTRO.COMMAND_CLEAR, data => !!this.utils.stringFromBase64(data));
       }
     });
@@ -294,17 +296,15 @@ export class BleService {
 
     _defineProperty(this, "updateLogInterval", async (macAddress, logInterval, clearLogs = true) => {
       const device = await this.connectAndDiscoverServices(macAddress);
+      // need to download logs for Blue maestro or BT250 before clearing logs
+      if (clearLogs) {
+        await this.downloadLogs(macAddress);
+      }
       const command = device.deviceType.COMMAND_UPDATE_LOG_INTERVAL.replace('LOG_INTERVAL', logInterval.toString());
       const result = await this.writeWithSingleResponse(device, command, data => {
         const info = this.utils.stringFromBase64(data);
         return device.deviceType === BT510 && JSON.parse(info).result === 'ok' || !!info.match(/interval/i);
-      }); // Clear logs if we haven't just downloaded
-      // BlueMaestro automatically clears logs when log interval is set,
-      // But we have to download all the logs to clear them on BT510
-
-      if (clearLogs && device.deviceType === BT510) {
-        await this.downloadLogs(macAddress);
-      }
+      }); 
 
       if (result) return true;
       throw new Error(` command returned not OK result`);

--- a/.yalc/msupply-ble-service/src/Bluetooth/BleService.ts
+++ b/.yalc/msupply-ble-service/src/Bluetooth/BleService.ts
@@ -279,6 +279,7 @@ export class BleService {
     if (device?.deviceType === BT510) {
       await this.downloadLogs(macAddress);
     } else {
+      await this.downloadLogs(macAddress);
       await this.writeWithSingleResponse(
         device,
         BLUE_MAESTRO.COMMAND_CLEAR,
@@ -412,6 +413,11 @@ export class BleService {
     this.logger.debug(`${macAddress} Update log interval`);
     const device = await this.connectAndDiscoverServices(macAddress);
 
+    // Download logs before clearing logs either for BT510 or blue maestro
+    if (clearLogs) {
+      await this.downloadLogs(macAddress);
+    }
+    
     const command = device.deviceType.COMMAND_UPDATE_LOG_INTERVAL.replace(
       'LOG_INTERVAL',
       logInterval.toString()
@@ -423,12 +429,6 @@ export class BleService {
         !!info.match(/interval/i)
       );
     });
-    // Clear logs if we haven't just downloaded
-    // BlueMaestro automatically clears logs when log interval is set,
-    // But we have to download all the logs to clear them on BT510
-    if (clearLogs && device.deviceType === BT510) {
-      await this.downloadLogs(macAddress);
-    }
     if (result) return true;
     throw new Error(` command returned not OK result`);
   };

--- a/src/ui/screens/settings/SensorDetailSettingsScreen.tsx
+++ b/src/ui/screens/settings/SensorDetailSettingsScreen.tsx
@@ -47,7 +47,7 @@ export const SensorDetailSettingsScreen: FC<SensorDetailSettingsScreenProps> = (
   const dispatch = useDispatch();
   const { name, logInterval, macAddress, batteryLevel } = sensor ?? {};
   const { [macAddress]: isBlinking } = useSelector(BlinkSelector.isBlinking);
-
+  const getValue = logInterval;
   return (
     <SettingsList>
       <SettingsLoadingIndicatorRow
@@ -95,7 +95,12 @@ export const SensorDetailSettingsScreen: FC<SensorDetailSettingsScreenProps> = (
           metric={t('MINUTES')}
           onConfirm={({ value }: { value: number }) => {
             const newLogInterval = value * 60;
-            dispatch(ProgramAction.tryUpdateLogInterval(macAddress, newLogInterval));
+            //let use edit interval if its 5 min which is default value and 
+            if (getValue == 300){
+              if (getValue != newLogInterval) {
+                dispatch(ProgramAction.tryUpdateLogInterval(macAddress, newLogInterval));
+              }
+            }
           }}
           editDescription={t('EDIT_LOG_INTERVAL')}
         />


### PR DESCRIPTION
Fixes #232 

As per discussion with @adamdewey :
1. Let's not let the user change the interval. Only at first, we will let them change the interval.
2. Second it seems Blue Maestro whenever the update command is fired deletes the log from msupply. But for BT250 we are downloading logs manually. So changed now that whether its BT250 or Blue maestro we want to download logs first then let the delete if it's needed as we see the after every download updateloginterval is running.