### PR TITLE
252 cca sync stops during server backup tablet needs to be restarted

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ See [https://docs.msupply.foundation/en:cold_chain:start](https://docs.msupply.f
 - Install SDKMAN for managing Java versions: https://sdkman.io/.
 
 The application is using java v1.8 you may need to target a specific java version in order to run the app locally.
+e.g.
+
+```
+export JDK_HOME=~/.jenv/versions/oracle64-1.8.0.192 && JAVA_HOME=~/.jenv/versions/oracle64-1.8.0.192 && yarn start
+```
 
 #### React Native
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mSupplyColdChain",
-  "version": "0.5.4",
+  "version": "0.5.5-rc1",
   "description": "Cold chain temperature monitoring",
   "author": "mSupply Foundation",
   "main": "index.ts",

--- a/src/common/constants/Setting.ts
+++ b/src/common/constants/Setting.ts
@@ -7,6 +7,7 @@ export const SYNC_SETTING = {
   AUTH_USERNAME: 'authUsername',
   AUTH_PASSWORD: 'authPassword',
   LAST_SYNC: 'lastSync',
+  LAST_SYNC_START: 'lastSyncStart',
   IS_PASSIVE_SYNC_ENABLED: 'isPassiveSyncEnabled',
   IS_INTEGRATING: 'isIntegrating',
 };

--- a/src/common/constants/Timeout.ts
+++ b/src/common/constants/Timeout.ts
@@ -1,0 +1,4 @@
+export const TIMEOUT = {
+  LOGIN_TIMEOUT: 20000,
+  HTTP_TIMEOUT: 60000,
+};

--- a/src/common/constants/index.ts
+++ b/src/common/constants/index.ts
@@ -25,3 +25,4 @@ export { ENVIRONMENT } from './Environment';
 export { SETTINGS_STACK } from './Navigation';
 
 export const RESTART_INTERVAL_IN_SECONDS = 60 * 60 * 24;
+export { TIMEOUT } from './Timeout';

--- a/src/common/services/Database/DatabaseService.ts
+++ b/src/common/services/Database/DatabaseService.ts
@@ -108,6 +108,16 @@ export class DatabaseService {
       });
     }
 
+    const lastSyncStart = await this.get(ENTITIES.SETTING, {
+      key: 'lastSyncStart',
+    });
+    if (!lastSyncStart) {
+      await this.upsert(ENTITIES.SETTING, {
+        key: 'lastSyncStart',
+        value: '0',
+      });
+    }
+
     const defaultLogInterval = await this.get(ENTITIES.SETTING, {
       key: 'defaultLogInterval',
     });

--- a/src/common/services/FormatService/FormatService.ts
+++ b/src/common/services/FormatService/FormatService.ts
@@ -59,6 +59,10 @@ export class FormatService {
     return moment.unix(date).format('DD-MM-YYYY-HH-mm-ss');
   };
 
+  dateTime = (date: number): string => {
+    return moment.unix(date).format('DD/MM/YYYY HH:mm:ss');
+  };
+
   temperature = (temperature: number): string => {
     return `${temperature}${SPECIAL_CHARACTER.DEGREE_CELSIUS}`;
   };

--- a/src/features/Entities/Setting/SettingManager.ts
+++ b/src/features/Entities/Setting/SettingManager.ts
@@ -13,6 +13,7 @@ const SettingKeys = [
   'authUsername',
   'authPassword',
   'lastSync',
+  'lastSyncStart',
   'isPassiveSyncEnabled',
   'isIntegrating',
   'defaultLogInterval',
@@ -25,6 +26,7 @@ export enum SettingType {
   authUsername = 'string',
   authPassword = 'string',
   lastSync = 'number',
+  lastSyncStart = 'number',
   defaultLogInterval = 'number',
   isPassiveSyncEnabled = 'bool',
   isIntegrating = 'bool',
@@ -35,6 +37,7 @@ export interface SettingMap {
   authUsername: string;
   authPassword: string;
   lastSync: number;
+  lastSyncStart: number;
   isPassiveSyncEnabled: boolean;
   isIntegrating: boolean;
   defaultLogInterval: number;
@@ -96,6 +99,7 @@ export class SettingManager {
       authUsername: '',
       authPassword: '',
       lastSync: 0,
+      lastSyncStart: 0,
       isPassiveSyncEnabled: false,
       isIntegrating: false,
       defaultLogInterval: 300,
@@ -108,14 +112,22 @@ export class SettingManager {
   };
 
   getSyncSettings = async (): Promise<SyncSettingMap> => {
-    const { serverUrl, authUsername, authPassword, lastSync, isPassiveSyncEnabled, isIntegrating } =
-      await this.getSettings();
+    const {
+      serverUrl,
+      authUsername,
+      authPassword,
+      lastSync,
+      lastSyncStart,
+      isPassiveSyncEnabled,
+      isIntegrating,
+    } = await this.getSettings();
 
     return {
       serverUrl,
       authUsername,
       authPassword,
       lastSync,
+      lastSyncStart,
       isPassiveSyncEnabled,
       isIntegrating,
     };

--- a/src/features/Entities/Setting/SettingSlice.ts
+++ b/src/features/Entities/Setting/SettingSlice.ts
@@ -14,6 +14,7 @@ const initialState: SettingStateShape = {
   authUsername: '',
   authPassword: '',
   lastSync: 0,
+  lastSyncStart: 0,
   isPassiveSyncEnabled: false,
   isIntegrating: false,
 };

--- a/src/features/Sync/SyncSlice.ts
+++ b/src/features/Sync/SyncSlice.ts
@@ -273,6 +273,8 @@ function* syncTemperatureBreaches({
 function* syncAll({
   payload: { serverUrl, authUsername, authPassword },
 }: PayloadAction<SyncAllPayload>): SagaIterator {
+  const utils: UtilService = yield call(getDependency, 'utilService');
+  yield put(SettingAction.update('lastSyncStart', utils.now()));
   yield put(SyncAction.updateIsSyncing(true));
   yield put(SyncAction.authenticate(`${serverUrl}/${ENDPOINT.LOGIN}`, authUsername, authPassword));
   const authenticateResult: PayloadAction<null> = yield take([

--- a/src/features/Sync/SyncSlice.ts
+++ b/src/features/Sync/SyncSlice.ts
@@ -303,7 +303,6 @@ function* syncAll({
 
 function* startSyncScheduler(): SagaIterator {
   while (true) {
-    console.log('startSyncScheduler');
     try {
       const settingManager: SettingManager = yield call(getDependency, 'settingManager');
       const syncSettings: SyncSettingMap = yield call(settingManager.getSyncSettings);

--- a/src/features/Sync/types.ts
+++ b/src/features/Sync/types.ts
@@ -94,7 +94,7 @@ export interface FetchAllSuccessActionPayload {
 
 export type SyncAllPayload = Omit<
   SyncSettingMap,
-  'lastSync' | 'isPassiveSyncEnabled' | 'isIntegrating'
+  'lastSync' | 'lastSyncStart' | 'isPassiveSyncEnabled' | 'isIntegrating'
 >;
 
 export interface SyncingErrorActionPayload {

--- a/src/ui/screens/settings/SyncSettingsScreen.tsx
+++ b/src/ui/screens/settings/SyncSettingsScreen.tsx
@@ -19,6 +19,7 @@ export const SyncSettingsScreen: FC = () => {
   );
 
   const syncQueueLength = useSelector(SyncSelector.getSyncQueueCount);
+  const isSyncing = useSelector(SyncSelector.getIsSyncing);
 
   const dispatch = useDispatch();
 
@@ -97,7 +98,12 @@ export const SyncSettingsScreen: FC = () => {
         <SettingsGroup title="Info">
           <SettingsItem
             label="Number of records to send"
-            subtext={String(syncQueueLength)}
+            subtext={syncQueueLength > 0 ? String(syncQueueLength) : 'No records to send'}
+            isDisabled
+          />
+          <SettingsItem
+            label="Sync"
+            subtext={isSyncing ? 'Syncing...' : 'Waiting to Sync...'}
             isDisabled
           />
         </SettingsGroup>

--- a/src/ui/screens/settings/SyncSettingsScreen.tsx
+++ b/src/ui/screens/settings/SyncSettingsScreen.tsx
@@ -21,6 +21,16 @@ export const SyncSettingsScreen: FC = () => {
   const syncQueueLength = useSelector(SyncSelector.getSyncQueueCount);
   const isSyncing = useSelector(SyncSelector.getIsSyncing);
 
+  const syncStatus = () => {
+    if (!isIntegrating) {
+      return 'Disabled';
+    }
+    if (isSyncing) {
+      return 'Syncing in progress';
+    }
+    return 'Ready to sync';
+  };
+
   const dispatch = useDispatch();
 
   useOnMount([
@@ -98,14 +108,10 @@ export const SyncSettingsScreen: FC = () => {
         <SettingsGroup title="Info">
           <SettingsItem
             label="Number of records to send"
-            subtext={syncQueueLength > 0 ? String(syncQueueLength) : 'No records to send'}
+            subtext={String(syncQueueLength)}
             isDisabled
           />
-          <SettingsItem
-            label="Sync"
-            subtext={isSyncing ? 'Syncing...' : 'Waiting to Sync...'}
-            isDisabled
-          />
+          <SettingsItem label="Sync" subtext={syncStatus()} isDisabled />
         </SettingsGroup>
       </SettingsGroup>
     </SettingsList>


### PR DESCRIPTION
Closes #252 

By default axios (our API request framework) doesn't timeout network connections if they hang.
It seems likely that during the server backup, since mSupply Server API Requests simply hang and the Sync `Saga` simply hangs waiting for the connection to finish. 

If the connection is hung for a long time (say 20minutes) the connection appears to be timed out somewhere in the OS or network layer, but this isn't correctly handled in our application.

With this change, we've added a request timeout which returns an error if the connection can't be made to the server.

We've also slightly improved some of the logging and error handling, including a sync status section in the configuation.

![image](https://github.com/openmsupply/msupply-cold-chain/assets/8287373/032e6877-fd85-4dd7-9bf8-92c0613af604)
