### PR TITLE
Keep app awake

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.WAKE_LOCK" />
   <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher" android:allowBackup="false" android:theme="@style/AppTheme" android:usesCleartextTraffic="true" android:requestLegacyExternalStorage="true">
     <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode" android:launchMode="singleTask" android:theme="@style/Theme.App.SplashScreen">

--- a/android/app/src/main/java/com/msupplycoldchain/MainActivity.java
+++ b/android/app/src/main/java/com/msupplycoldchain/MainActivity.java
@@ -27,25 +27,9 @@ public class MainActivity extends ReactActivity {
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
-//    PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
-//    this.wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, packageName + "::MyWakelockTag");
-//    this.wakeLock.acquire();
-
     super.onCreate(null);
     Bugsnag.start(this); 
 
     // SplashScreen.show(...) has to be called after super.onCreate(...)
     SplashScreen.show(this, SplashScreenImageResizeMode.COVER, ReactRootView.class, false);
   }
-
-//  @Override
-//  protected void onDestroy() {
-//    try {
-//      this.wakeLock.release();
-//    }
-//    catch(Exception e) {
-//
-//    }
-//    super.onDestroy();
-//  }
-}

--- a/android/app/src/main/java/com/msupplycoldchain/MainActivity.java
+++ b/android/app/src/main/java/com/msupplycoldchain/MainActivity.java
@@ -2,6 +2,8 @@ package com.msupplycoldchain;
 
 // Used for overriding onCreate
 import android.os.Bundle;
+import android.os.PowerManager;
+
 import com.bugsnag.android.Bugsnag;
 
 // Used to create the splash screen on start up.
@@ -17,13 +19,22 @@ public class MainActivity extends ReactActivity {
    * Returns the name of the main component registered from JavaScript. This is used to schedule
    * rendering of the component.
    */
+
+  String packageName = "mSupplyColdChain";
+  PowerManager.WakeLock wakeLock;
+
   @Override
   protected String getMainComponentName() {
-    return "mSupplyColdChain";
+    return packageName;
   }
+
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
+    PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
+    this.wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, packageName + "::MyWakelockTag");
+    this.wakeLock.acquire();
+
     super.onCreate(null);
     Bugsnag.start(this); 
 
@@ -31,5 +42,14 @@ public class MainActivity extends ReactActivity {
     SplashScreen.show(this, SplashScreenImageResizeMode.COVER, ReactRootView.class, false);
   }
 
+  @Override
+  protected void onDestroy() {
+    try {
+      this.wakeLock.release();
+    }
+    catch(Exception e) {
 
+    }
+    super.onDestroy();
+  }
 }

--- a/android/app/src/main/java/com/msupplycoldchain/MainActivity.java
+++ b/android/app/src/main/java/com/msupplycoldchain/MainActivity.java
@@ -19,21 +19,17 @@ public class MainActivity extends ReactActivity {
    * Returns the name of the main component registered from JavaScript. This is used to schedule
    * rendering of the component.
    */
-
-  String packageName = "mSupplyColdChain";
-  PowerManager.WakeLock wakeLock;
-
   @Override
   protected String getMainComponentName() {
-    return packageName;
+    return "mSupplyColdChain";
   }
 
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
-    PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
-    this.wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, packageName + "::MyWakelockTag");
-    this.wakeLock.acquire();
+//    PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
+//    this.wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, packageName + "::MyWakelockTag");
+//    this.wakeLock.acquire();
 
     super.onCreate(null);
     Bugsnag.start(this); 
@@ -42,14 +38,14 @@ public class MainActivity extends ReactActivity {
     SplashScreen.show(this, SplashScreenImageResizeMode.COVER, ReactRootView.class, false);
   }
 
-  @Override
-  protected void onDestroy() {
-    try {
-      this.wakeLock.release();
-    }
-    catch(Exception e) {
-
-    }
-    super.onDestroy();
-  }
+//  @Override
+//  protected void onDestroy() {
+//    try {
+//      this.wakeLock.release();
+//    }
+//    catch(Exception e) {
+//
+//    }
+//    super.onDestroy();
+//  }
 }

--- a/android/app/src/main/java/com/msupplycoldchain/MainApplication.java
+++ b/android/app/src/main/java/com/msupplycoldchain/MainApplication.java
@@ -1,24 +1,10 @@
 package com.msupplycoldchain;
 import android.app.Application;
 import android.content.Context;
+import android.os.PowerManager;
+
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
-import org.reactnative.maskedview.RNCMaskedViewPackage;
-import com.reactnativerestart.RestartPackage;
-import com.bugsnag.android.BugsnagPackage;
-import com.chirag.RNMail.RNMail;
-import com.ninty.system.setting.SystemSettingPackage;
-import com.reactcommunity.rnlocalize.RNLocalizePackage;
-import com.rnfs.RNFSPackage;
-import com.polidea.reactnativeble.BlePackage;
-import com.horcrux.svg.SvgPackage;
-import com.learnium.RNDeviceInfo.RNDeviceInfo;
-import com.oblador.vectoricons.VectorIconsPackage;
-import com.swmansion.rnscreens.RNScreensPackage;
-import com.th3rdwave.safeareacontext.SafeAreaContextPackage;
-import com.reactcommunity.rnlocalize.RNLocalizePackage;
-import com.swmansion.gesturehandler.react.RNGestureHandlerPackage;
-import com.reactnativecommunity.asyncstorage.AsyncStoragePackage;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
@@ -29,11 +15,11 @@ import java.util.Arrays;
 import com.msupplycoldchain.generated.BasePackageList;
 import org.unimodules.adapters.react.ModuleRegistryAdapter;
 import org.unimodules.adapters.react.ReactModuleRegistryProvider;
-import org.unimodules.core.interfaces.SingletonModule;
 
 public class MainApplication extends Application implements ReactApplication {
 
   private final ReactModuleRegistryProvider mModuleRegistryProvider = new ReactModuleRegistryProvider(new BasePackageList().getPackageList(), null);
+  private PowerManager.WakeLock wakeLock;
 
   private final ReactNativeHost mReactNativeHost =
       new ReactNativeHost(this) {
@@ -72,7 +58,24 @@ public class MainApplication extends Application implements ReactApplication {
     super.onCreate();
     SoLoader.init(this, false);
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+
+    // acquire a wakelock which will keeps the app running regardless of screen saving
+    // and battery optimisation
+    PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
+    this.wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK,"mSupplyColdChain::MyWakelockTag");
+    this.wakeLock.acquire();
   }
+
+    @Override
+    public void onTerminate() {
+        try {
+            this.wakeLock.release();
+        }
+        catch(Exception e) {
+
+        }
+        super.onTerminate();
+    }
 
   /**
    * Loads Flipper in React Native templates. Call this in the onCreate method with something like

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mSupplyColdChain",
-  "version": "0.5.5-rc1",
+  "version": "0.5.5-rc2",
   "description": "Cold chain temperature monitoring",
   "author": "mSupply Foundation",
   "main": "index.ts",


### PR DESCRIPTION
Fixes #255 

This is the 'please drain my battery' option 😉 
This will implement a [wakelock](https://developer.android.com/training/scheduling/wakelock) to allow the app to keep interacting and uploading data even when the screen is being saved.

To test: configure a sensor and sync. Start the app, plug the tablet in and see if it continues to sync over 2+ days.